### PR TITLE
#70 desktop/ProductCard: добавить возможность задавать z-index

### DIFF
--- a/src/desktop/components/product-card/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/desktop/components/product-card/__test__/__snapshots__/index.test.tsx.snap
@@ -105,6 +105,7 @@ exports[`ProductCard should render hover card correctly 1`] = `
     <div
       class="bg-color__white card shadow-z4 rounds-md__all"
       data-testid="product-card:hover-card"
+      style="z-index: 1;"
     >
       <div
         class="root image-overlay"

--- a/src/desktop/components/product-card/__test__/index.test.tsx
+++ b/src/desktop/components/product-card/__test__/index.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render } from '@testing-library/react';
 import { ProductCard } from '..';
 import { ProductInfo, Parts } from '../../../../common/components/product-info';
 import { Button } from '@sima-land/ui-nucleons/button';
+import { LayerProvider } from '@sima-land/ui-nucleons/helpers/layer';
 
 const data = {
   name: 'Some product',
@@ -83,5 +84,34 @@ describe('ProductCard', () => {
 
     expect(queryByTestId('product-card:hover-card')).toBe(null);
     expect(queryByTestId('product-info:footer')).toBe(null);
+  });
+
+  it('should handle layer', () => {
+    const { getByTestId } = render(
+      <LayerProvider value={10}>
+        <ProductCard>
+          <ProductInfo>
+            <Parts.Image src={data.imageSrc} href={data.url} />
+
+            <Parts.Prices
+              price={data.price}
+              oldPrice={data.oldPrice}
+              currencyGrapheme={data.currencyGrapheme}
+            />
+
+            <Parts.Title href={data.url}>{data.name}</Parts.Title>
+
+            <Parts.Footer>
+              <Parts.CartControl>
+                <Button>В корзину</Button>
+              </Parts.CartControl>
+            </Parts.Footer>
+          </ProductInfo>
+        </ProductCard>
+      </LayerProvider>,
+    );
+
+    fireEvent.mouseEnter(getByTestId('product-card:info'));
+    expect(getByTestId('product-card:hover-card').style.zIndex).toBe('11');
   });
 });

--- a/src/desktop/components/product-card/index.tsx
+++ b/src/desktop/components/product-card/index.tsx
@@ -1,6 +1,7 @@
 import React, { Children, forwardRef, isValidElement, cloneElement, useState } from 'react';
 import { ProductInfo, ProductInfoProps, Parts } from '../../../common/components/product-info';
 import { Plate, PlateProps } from '@sima-land/ui-nucleons/plate';
+import { useLayer } from '@sima-land/ui-nucleons/helpers/layer';
 import cn from 'classnames';
 import styles from './product-card.module.scss';
 
@@ -10,16 +11,21 @@ export interface ProductCardProps extends React.HTMLAttributes<HTMLDivElement> {
   children: ProductCardChildren;
 }
 
-export const HoverCard = forwardRef<HTMLDivElement | null, PlateProps>((props, ref) => (
-  <Plate
-    {...props}
-    ref={ref}
-    rounds='m'
-    shadow='z4'
-    className={cn(styles.card, props.className)}
-    data-testid='product-card:hover-card'
-  />
-));
+export const HoverCard = forwardRef<HTMLDivElement | null, PlateProps>((props, ref) => {
+  const layer = useLayer() + 1;
+
+  return (
+    <Plate
+      {...props}
+      style={{ ...props.style, zIndex: layer }}
+      ref={ref}
+      rounds='m'
+      shadow='z4'
+      className={cn(styles.card, props.className)}
+      data-testid='product-card:hover-card'
+    />
+  );
+});
 
 export const ProductCard = ({ children, className, ...props }: ProductCardProps) => {
   const [hovered, toggle] = useState<boolean>(false);

--- a/src/desktop/components/product-carousel/__test__/__snapshots__/hover-card.test.tsx.snap
+++ b/src/desktop/components/product-carousel/__test__/__snapshots__/hover-card.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`<HoverCard /> should renders hidden 1`] = `
       style={
         Object {
           "padding": "16px 16px 24px 16px",
+          "zIndex": 1,
         }
       }
     >
@@ -36,6 +37,7 @@ exports[`<HoverCard /> should renders hidden 1`] = `
         style={
           Object {
             "padding": "16px 16px 24px 16px",
+            "zIndex": 1,
           }
         }
       >
@@ -78,6 +80,7 @@ Array [
         style={
           Object {
             "padding": "16px 16px 24px 16px",
+            "zIndex": 1,
           }
         }
       >
@@ -88,6 +91,7 @@ Array [
           style={
             Object {
               "padding": "16px 16px 24px 16px",
+              "zIndex": 1,
             }
           }
         >

--- a/src/desktop/components/product-carousel/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/desktop/components/product-carousel/__test__/__snapshots__/index.test.tsx.snap
@@ -416,7 +416,7 @@ exports[`<ProductCarousel /> should renders correctly 1`] = `
       <button
         class="arrow-button size-s control backward"
         data-testid="arrow-button"
-        style="z-index: 1; top: 0px;"
+        style="z-index: 2; top: 0px;"
         type="button"
       >
         <svg
@@ -434,7 +434,7 @@ exports[`<ProductCarousel /> should renders correctly 1`] = `
       <button
         class="arrow-button size-s control forward"
         data-testid="arrow-button"
-        style="z-index: 1; top: 0px;"
+        style="z-index: 2; top: 0px;"
         type="button"
       >
         <svg
@@ -516,7 +516,7 @@ exports[`<ProductCarousel /> should renders correctly with only one item 1`] = `
       <button
         class="arrow-button size-s control backward"
         data-testid="arrow-button"
-        style="z-index: 1; top: 0px;"
+        style="z-index: 2; top: 0px;"
         type="button"
       >
         <svg
@@ -534,7 +534,7 @@ exports[`<ProductCarousel /> should renders correctly with only one item 1`] = `
       <button
         class="arrow-button size-s control forward"
         data-testid="arrow-button"
-        style="z-index: 1; top: 0px;"
+        style="z-index: 2; top: 0px;"
         type="button"
       >
         <svg
@@ -573,7 +573,7 @@ exports[`<ProductCarousel /> should set size depend on media query 1`] = `
           "size": "s",
           "style": Object {
             "top": "0px",
-            "zIndex": 1,
+            "zIndex": 2,
           },
         }
       }
@@ -2086,7 +2086,7 @@ exports[`<ProductCarousel /> should set size depend on media query 1`] = `
           style={
             Object {
               "top": "0px",
-              "zIndex": 1,
+              "zIndex": 2,
             }
           }
         >
@@ -2098,7 +2098,7 @@ exports[`<ProductCarousel /> should set size depend on media query 1`] = `
             style={
               Object {
                 "top": "0px",
-                "zIndex": 1,
+                "zIndex": 2,
               }
             }
             type="button"
@@ -2130,7 +2130,7 @@ exports[`<ProductCarousel /> should set size depend on media query 1`] = `
           style={
             Object {
               "top": "0px",
-              "zIndex": 1,
+              "zIndex": 2,
             }
           }
         >
@@ -2142,7 +2142,7 @@ exports[`<ProductCarousel /> should set size depend on media query 1`] = `
             style={
               Object {
                 "top": "0px",
-                "zIndex": 1,
+                "zIndex": 2,
               }
             }
             type="button"
@@ -2184,7 +2184,7 @@ exports[`<ProductCarousel /> should set size depend on media query 2`] = `
           "size": "l",
           "style": Object {
             "top": "0px",
-            "zIndex": 1,
+            "zIndex": 2,
           },
         }
       }
@@ -3697,7 +3697,7 @@ exports[`<ProductCarousel /> should set size depend on media query 2`] = `
           style={
             Object {
               "top": "0px",
-              "zIndex": 1,
+              "zIndex": 2,
             }
           }
         >
@@ -3709,7 +3709,7 @@ exports[`<ProductCarousel /> should set size depend on media query 2`] = `
             style={
               Object {
                 "top": "0px",
-                "zIndex": 1,
+                "zIndex": 2,
               }
             }
             type="button"
@@ -3748,7 +3748,7 @@ exports[`<ProductCarousel /> should set size depend on media query 2`] = `
           style={
             Object {
               "top": "0px",
-              "zIndex": 1,
+              "zIndex": 2,
             }
           }
         >
@@ -3760,7 +3760,7 @@ exports[`<ProductCarousel /> should set size depend on media query 2`] = `
             style={
               Object {
                 "top": "0px",
-                "zIndex": 1,
+                "zIndex": 2,
               }
             }
             type="button"

--- a/src/desktop/components/product-carousel/__test__/index.test.tsx
+++ b/src/desktop/components/product-carousel/__test__/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { mount, ReactWrapper } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { ProductCarousel } from '..';
@@ -8,6 +8,7 @@ import { useMedia } from '@sima-land/ui-nucleons/hooks/media';
 import { HoverCard } from '../hover-card';
 import { Carousel } from '@sima-land/ui-nucleons/carousel';
 import { Parts, ProductInfo } from '../../../../common/components/product-info';
+import { LayerProvider } from '@sima-land/ui-nucleons/helpers/layer';
 
 jest.mock('@sima-land/ui-nucleons/hooks/media', () => {
   const original = jest.requireActual('@sima-land/ui-nucleons/hooks/media');
@@ -238,5 +239,34 @@ describe('<ProductCarousel />', () => {
     wrapper.update();
 
     expect(Find.hoverCardItemName(wrapper)).toBe(items[0].name);
+  });
+
+  it('should handle layer', () => {
+    const { getByTestId, getAllByTestId } = render(
+      <LayerProvider value={20}>
+        <ProductCarousel itemSize={{ xs: 3 }} withHoverCard>
+          {items.map((item, index) => (
+            <ProductInfo key={index}>
+              <Parts.Image src={item.imageSrc} href={item.url} />
+
+              <Parts.Prices
+                price={item.price}
+                oldPrice={item.oldPrice}
+                currencyGrapheme={item.currencyGrapheme}
+              />
+
+              <Parts.Title href={item.url}>{item.name}</Parts.Title>
+            </ProductInfo>
+          ))}
+        </ProductCarousel>
+      </LayerProvider>,
+    );
+
+    fireEvent.mouseEnter(getAllByTestId('product-carousel:item')[0]);
+
+    expect(getByTestId('product-card:hover-card').style.zIndex).toBe('21');
+    getAllByTestId('arrow-button').forEach(button => {
+      expect(button.style.zIndex).toBe('22');
+    });
   });
 });

--- a/src/desktop/components/product-carousel/index.tsx
+++ b/src/desktop/components/product-carousel/index.tsx
@@ -6,6 +6,7 @@ import { useMedia } from '@sima-land/ui-nucleons/hooks/media';
 import { ProductInfo, ProductInfoProps, Parts } from '../../../common/components/product-info';
 import classnames from 'classnames/bind';
 import styles from './product-carousel.module.scss';
+import { useLayer } from '@sima-land/ui-nucleons/helpers/layer';
 
 interface ItemSize {
   xs?: 2 | 3 | 4;
@@ -60,6 +61,7 @@ export const ProductCarousel = ({
   withHoverCard,
   children,
 }: ProductCarouselProps) => {
+  const layer = useLayer();
   const [activeItemIndex, setActiveItemIndex] = useState<number | null>(null);
   const cardShow = useAllowFlag();
   const needBigArrows = useMedia('(min-width: 1600px)');
@@ -98,7 +100,7 @@ export const ProductCarousel = ({
             controlProps: {
               size: needBigArrows ? 'l' : 's',
               style: {
-                zIndex: 1,
+                zIndex: layer + 2, // чтобы кнопки были над HoverCard
                 top: `${itemWidth / 2}px`,
               },
             },

--- a/src/desktop/components/product-carousel/utils.ts
+++ b/src/desktop/components/product-carousel/utils.ts
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import on from '@sima-land/ui-nucleons/helpers/on';
+import { useIdentityRef } from '@sima-land/ui-nucleons/hooks/identity';
 
 /**
  * Вызывает callback когда заданный в ref элемент попал во viewport.
@@ -12,13 +13,17 @@ export const useViewport = (
   callback?: () => void,
   options?: IntersectionObserverInit,
 ) => {
+  const callbackRef = useIdentityRef(callback);
+
   useEffect(() => {
     const element = ref.current;
 
     if (element) {
       const observer = new IntersectionObserver(entries => {
+        const fn = callbackRef.current;
+
         for (const entry of entries) {
-          entry.target === element && entry.isIntersecting && callback && callback();
+          entry.target === element && entry.isIntersecting && fn && fn();
           break;
         }
       }, options);


### PR DESCRIPTION
- `desktop/ProductCard`: добавлена обработка контекста слоя (minor)
- `desktop/ProductCarousel`: добавлена обработка контекста (minor)
- `useViewport`: исправлено отсутствие обработки смены callback'а (patch)

Closes #70 