### PR TITLE
#98  InteractiveImage: добавить ref forwarding

### DIFF
--- a/src/common/components/intractive-image/__test__/index.test.tsx
+++ b/src/common/components/intractive-image/__test__/index.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import React from 'react';
+import React, { createRef } from 'react';
 import { InteractiveImage, Parts } from '..';
 
 describe('InteractiveImage', () => {
@@ -18,5 +18,21 @@ describe('InteractiveImage', () => {
 
     expect(queryAllByTestId('interactive-image:image')).toHaveLength(1);
     expect(queryAllByTestId('interactive-image:point')).toHaveLength(4);
+  });
+
+  it('should take ref', () => {
+    const ref = createRef<HTMLDivElement>();
+
+    const { getByTestId } = render(
+      <InteractiveImage ref={ref} data-testid='test-root'>
+        <Parts.Image src='https://www.images.com/123' />
+        <Parts.Point role='button' x={1} y={2} />
+        <Parts.Point role='button' x={2} y={3} />
+        <Parts.Point role='button' x={3} y={4} />
+        <Parts.Point role='button' x={4} y={5} />
+      </InteractiveImage>,
+    );
+
+    expect(ref.current).toBe(getByTestId('test-root'));
   });
 });

--- a/src/common/components/intractive-image/index.tsx
+++ b/src/common/components/intractive-image/index.tsx
@@ -17,17 +17,14 @@ export interface InteractiveImagePointProps extends React.AnchorHTMLAttributes<H
   'data-testid'?: string;
 }
 
-export const InteractiveImage = ({
-  children,
-  'data-testid': testId,
-  className,
-  ...rest
-}: InteractiveImageProps) => (
-  <div className={classNames(styles.root, className)} {...rest} data-testid={testId}>
-    {Children.toArray(children).filter(
-      child => isValidElement(child) && (child.type === Image || child.type === Point),
-    )}
-  </div>
+export const InteractiveImage = forwardRef<HTMLDivElement, InteractiveImageProps>(
+  ({ children, 'data-testid': testId, className, ...rest }, ref) => (
+    <div ref={ref} className={classNames(styles.root, className)} {...rest} data-testid={testId}>
+      {Children.toArray(children).filter(
+        child => isValidElement(child) && (child.type === Image || child.type === Point),
+      )}
+    </div>
+  ),
 );
 
 const Image = forwardRef<HTMLImageElement, InteractiveImageImageProps>(


### PR DESCRIPTION
- `InteractiveImage`: добавлена возможность задать ref для корневого элемента (minor)

Closes #98 