### PR TITLE
#115 ProductSlider: футер должен быть на одной линии по вертикали

### DIFF
--- a/src/common/components/product-info/parts.tsx
+++ b/src/common/components/product-info/parts.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { createContext, useContext } from 'react';
 import { Link, LinkProps } from '@sima-land/ui-nucleons/link';
 import { Price } from '@sima-land/ui-nucleons/price';
 import { StrokedSVG, StrokedSVGProps } from '@sima-land/ui-nucleons/stroked-svg';
@@ -210,16 +210,24 @@ const TrademarkLink = ({
   />
 );
 
+const FooterContext = createContext<{ className?: string }>({
+  className: undefined,
+});
+
 /**
  * Слот - футер.
  * @param props Свойства.
  * @return Элемент.
  */
-const Footer: React.FC = ({ children }) => (
-  <div className={cx('footer')} data-testid='product-info:footer'>
-    {children}
-  </div>
-);
+const Footer: React.FC = ({ children }) => {
+  const { className = cx('footer') } = useContext(FooterContext);
+
+  return (
+    <div className={className} data-testid='product-info:footer'>
+      {children}
+    </div>
+  );
+};
 
 /**
  * Блок управления корзиной.
@@ -318,6 +326,7 @@ export const Parts = {
 
   // компоненты-слоты и компоненты-запчасти, предназначенные для вывода футера (dcе что ниже ссылки на торговую марку)
   Footer,
+  FooterContext,
   CartControl,
   AdultConfirmButton,
   WaitListAddButton,

--- a/src/mobile/components/product-slider/__stories__/index.stories.tsx
+++ b/src/mobile/components/product-slider/__stories__/index.stories.tsx
@@ -110,6 +110,8 @@ export const Primary = () => {
   );
 };
 
+Primary.storyName = 'Простой пример';
+
 export const Unavailable = () => (
   <Bootstrap>
     <ProductSlider>
@@ -150,6 +152,8 @@ export const Unavailable = () => (
   </Bootstrap>
 );
 
+Unavailable.storyName = 'Недоступные товары';
+
 export const Adult = () => (
   <Bootstrap>
     <ProductSlider>
@@ -188,3 +192,5 @@ export const Adult = () => (
     </ProductSlider>
   </Bootstrap>
 );
+
+Adult.storyName = 'Товары для взрослых';

--- a/src/mobile/components/product-slider/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/mobile/components/product-slider/__test__/__snapshots__/index.test.tsx.snap
@@ -327,7 +327,7 @@ exports[`<ProductSlider /> should renders correctly 1`] = `
               data-testid="product-info:name-link"
               href=""
             >
-              Ножницы портновские, 31 см, цвет чёрный/голубой
+              Ножницы портновские
             </a>
             <div
               class="footer"
@@ -2302,7 +2302,7 @@ Array [
       data-testid="product-info:name-link"
       href=""
     >
-      Ножницы портновские, 31 см, цвет чёрный/голубой
+      Ножницы портновские
     </a>
     <div
       class="footer"

--- a/src/mobile/components/product-slider/__test__/test-items.ts
+++ b/src/mobile/components/product-slider/__test__/test-items.ts
@@ -41,7 +41,7 @@ export const items: TestItem[] = [
     trademark: { name: 'Торговая марка Сима-ленд', url: 'https://sima-land.ru' },
   },
   {
-    name: 'Ножницы портновские, 31 см, цвет чёрный/голубой',
+    name: 'Ножницы портновские',
     imageSrc: 'https://cdn3.static1-sima-land.com/items/2300382/0/280.jpg?v=1594121798',
     imageAlt: 'Ножницы портновские, 31 см, цвет чёрный/голубой, Ножницы',
     url: '',

--- a/src/mobile/components/product-slider/index.tsx
+++ b/src/mobile/components/product-slider/index.tsx
@@ -1,7 +1,7 @@
 import React, { Children, isValidElement, useMemo, useRef } from 'react';
 import { useIntersection } from '@sima-land/ui-nucleons/hooks/intersection';
 import { TouchSlider } from '@sima-land/ui-nucleons/touch-slider';
-import { ProductInfo, ProductInfoProps } from '../../../common/components/product-info';
+import { ProductInfo, ProductInfoProps, Parts } from '../../../common/components/product-info';
 import styles from './product-slider.module.scss';
 
 export type ItemElement = React.ReactElement<ProductInfoProps, typeof ProductInfo>;
@@ -43,17 +43,19 @@ export const ProductSlider = ({ children, onInViewport, onNeedRequest }: Product
   return (
     <div ref={rootRef} data-testid='product-slider:root'>
       <TouchSlider>
-        {Children.toArray(children).reduce<React.ReactElement[]>((list, item) => {
-          isValidElement(item) &&
-            item.type === ProductInfo &&
-            list.push(
-              <div key={item.key} className={styles.item} data-testid='product-slider:item'>
-                {item}
-              </div>,
-            );
+        <Parts.FooterContext.Provider value={{ className: styles.footer }}>
+          {Children.toArray(children).reduce<React.ReactElement[]>((list, item) => {
+            isValidElement(item) &&
+              item.type === ProductInfo &&
+              list.push(
+                <div key={item.key} className={styles.item} data-testid='product-slider:item'>
+                  {item}
+                </div>,
+              );
 
-          return list;
-        }, [])}
+            return list;
+          }, [])}
+        </Parts.FooterContext.Provider>
       </TouchSlider>
     </div>
   );

--- a/src/mobile/components/product-slider/product-slider.module.scss
+++ b/src/mobile/components/product-slider/product-slider.module.scss
@@ -1,6 +1,8 @@
 @use 'node_modules/@sima-land/ui-nucleons/breakpoints';
 
 .item {
+  display: flex;
+  flex-direction: column;
   position: relative;
   flex-shrink: 0;
   width: 160px;
@@ -10,4 +12,9 @@
   &:not(:last-child) {
     margin-right: 16px;
   }
+}
+
+.footer {
+  margin-top: auto;
+  padding-top: 16px;
 }


### PR DESCRIPTION
- `ProductInfo`: добавлена возможность задавать css-класс для футера через контекст `FooterContext` (minor)
- `ProductSlider`: футеры элементов слйдера теперь на одном уровне по вертикали (patch)

Closes #115 