### PR TITLE
#127 Поправить размер точек у InteractiveImage

### DIFF
--- a/src/common/components/intractive-image/__stories__/index.stories.tsx
+++ b/src/common/components/intractive-image/__stories__/index.stories.tsx
@@ -1,5 +1,4 @@
-import { action } from '@storybook/addon-actions';
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import { InteractiveImage, Parts } from '..';
 import imageSrc from './image.png';
 
@@ -17,7 +16,7 @@ interface TitledPoint {
   title: string;
 }
 
-export const Primary = () => {
+export function Primary() {
   const points: TitledPoint[] = [
     { x: 28, y: 30, title: 'Яйца' },
     { x: 63, y: 35, title: 'Кружка' },
@@ -25,15 +24,15 @@ export const Primary = () => {
     { x: 83, y: 69, title: 'Приборы' },
   ];
 
-  const style: React.CSSProperties = {
+  const style: CSSProperties = {
     borderRadius: '8px',
     width: '600px',
     maxWidth: '100%',
     marginBottom: '32px',
   };
 
-  const ClickHandler = (value: string) => () => {
-    action('click')(value);
+  const onPointClick = (point: TitledPoint) => {
+    alert(`Клик по точке "${point.title}"`);
   };
 
   return (
@@ -46,11 +45,11 @@ export const Primary = () => {
         <Parts.Image src={imageSrc} />
 
         {points.map((point, index) => (
-          <Parts.Point key={index} role='button' {...point} onClick={ClickHandler(point.title)} />
+          <Parts.Point key={index} role='button' {...point} onClick={() => onPointClick(point)} />
         ))}
       </InteractiveImage>
     </>
   );
-};
+}
 
 Primary.storyName = 'Простой пример';

--- a/src/common/components/intractive-image/__test__/index.test.tsx
+++ b/src/common/components/intractive-image/__test__/index.test.tsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react';
 import React, { createRef } from 'react';
+import { render } from '@testing-library/react';
 import { InteractiveImage, Parts } from '..';
 
 describe('InteractiveImage', () => {
@@ -34,5 +34,19 @@ describe('InteractiveImage', () => {
     );
 
     expect(ref.current).toBe(getByTestId('test-root'));
+  });
+
+  it('should handle "dotSize" prop', () => {
+    const { getByTestId } = render(
+      <InteractiveImage dotSize='unset' data-testid='interactive-image'>
+        <Parts.Image src='https://www.images.com/123' />
+        <Parts.Point role='button' x={1} y={2} />
+        <Parts.Point role='button' x={2} y={3} />
+        <Parts.Point role='button' x={3} y={4} />
+        <Parts.Point role='button' x={4} y={5} />
+      </InteractiveImage>,
+    );
+
+    expect(getByTestId('interactive-image').classList.contains('dot-size-unset')).toBe(true);
   });
 });

--- a/src/common/components/intractive-image/index.tsx
+++ b/src/common/components/intractive-image/index.tsx
@@ -1,35 +1,37 @@
 import React, { Children, forwardRef, isValidElement } from 'react';
-import classNames from 'classnames';
+import {
+  InteractiveImageProps,
+  InteractiveImageImageProps,
+  InteractiveImagePointProps,
+} from './types';
+import classNames from 'classnames/bind';
 import styles from './interactive-image.module.scss';
 
-export interface InteractiveImageProps extends React.HTMLAttributes<HTMLDivElement> {
-  children?: React.ReactNode;
-  'data-testid'?: string;
-}
-
-export interface InteractiveImageImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
-  'data-testid'?: string;
-}
-
-export interface InteractiveImagePointProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
-  x: number;
-  y: number;
-  'data-testid'?: string;
-}
+const cx = classNames.bind(styles);
 
 export const InteractiveImage = forwardRef<HTMLDivElement, InteractiveImageProps>(
-  ({ children, 'data-testid': testId, className, ...rest }, ref) => (
-    <div ref={ref} className={classNames(styles.root, className)} {...rest} data-testid={testId}>
-      {Children.toArray(children).filter(
-        child => isValidElement(child) && (child.type === Image || child.type === Point),
-      )}
-    </div>
-  ),
+  ({ children, 'data-testid': testId, className, dotSize, ...rest }, ref) => {
+    const rootClassName = cx(
+      'root',
+      {
+        'dot-size-unset': dotSize === 'unset',
+      },
+      className,
+    );
+
+    return (
+      <div ref={ref} className={rootClassName} {...rest} data-testid={testId}>
+        {Children.toArray(children).filter(
+          child => isValidElement(child) && (child.type === Image || child.type === Point),
+        )}
+      </div>
+    );
+  },
 );
 
 const Image = forwardRef<HTMLImageElement, InteractiveImageImageProps>(
   ({ className, 'data-testid': testId = 'interactive-image:image', ...rest }, ref) => (
-    <img ref={ref} className={classNames(styles.image, className)} data-testid={testId} {...rest} />
+    <img ref={ref} className={cx('image', className)} data-testid={testId} {...rest} />
   ),
 );
 
@@ -39,7 +41,7 @@ const Point = forwardRef<HTMLAnchorElement, InteractiveImagePointProps>(
       ref={ref}
       aria-label='Точка на изображении'
       data-testid={testId}
-      className={classNames(styles.point, className)}
+      className={cx('point', className)}
       style={{ ...style, top: `${y}%`, left: `${x}%` }}
       {...rest}
     />

--- a/src/common/components/intractive-image/interactive-image-util.scss
+++ b/src/common/components/intractive-image/interactive-image-util.scss
@@ -1,0 +1,10 @@
+@use 'node_modules/@sima-land/ui-nucleons/breakpoints';
+
+@mixin dot-size-default {
+  --dot-size: 32px;
+  --dot-size-core: 12px;
+  @include breakpoints.down('xs') {
+    --dot-size: 40px;
+    --dot-size-core: 16px;
+  }
+}

--- a/src/common/components/intractive-image/interactive-image.module.scss
+++ b/src/common/components/intractive-image/interactive-image.module.scss
@@ -1,5 +1,6 @@
 @use 'node_modules/@sima-land/ui-nucleons/colors';
 @use 'node_modules/@sima-land/ui-nucleons/breakpoints';
+@use './interactive-image-util';
 
 .root {
   display: inline-block;
@@ -7,6 +8,9 @@
   position: relative;
   overflow: hidden;
   background: colors.$basic-gray4;
+  &:not(.dot-size-unset) {
+    @include interactive-image-util.dot-size-default;
+  }
 }
 
 .image {
@@ -22,8 +26,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 52px;
-  height: 52px;
+  width: var(--dot-size, 32px);
+  height: var(--dot-size, 32px);
   background: rgba(colors.$basic-gray87, 0.4);
   border-radius: 50%;
   transform: translate(-50%, -50%);
@@ -34,17 +38,9 @@
   &::after {
     content: '';
     display: block;
-    width: 20px;
-    height: 20px;
+    width: var(--dot-size-core, 12px);
+    height: var(--dot-size-core, 12px);
     background: #fff;
     border-radius: 50%;
-  }
-  @include breakpoints.down('xs') {
-    width: 40px;
-    height: 40px;
-    &::after {
-      width: 16px;
-      height: 16px;
-    }
   }
 }

--- a/src/common/components/intractive-image/types.ts
+++ b/src/common/components/intractive-image/types.ts
@@ -1,0 +1,30 @@
+import type { CSSProperties } from 'react';
+
+export interface InteractiveImageStyle extends CSSProperties {
+  '--dot-size'?: string;
+  '--dot-size-core'?: string;
+}
+
+export interface InteractiveImageProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Размер точек. При указании "unset" можно задать css-переменные через className или style. */
+  dotSize?: 'unset';
+
+  /** Стили с возможностью указания размера точек через css-переменные. */
+  style?: InteractiveImageStyle;
+
+  /** Идентификатор для систем автоматизированного тестирования. */
+  'data-testid'?: string;
+}
+
+export interface InteractiveImageImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  /** Идентификатор для систем автоматизированного тестирования. */
+  'data-testid'?: string;
+}
+
+export interface InteractiveImagePointProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  x: number;
+  y: number;
+
+  /** Идентификатор для систем автоматизированного тестирования. */
+  'data-testid'?: string;
+}


### PR DESCRIPTION
- `interactive-image`: типы вынесены в `types.ts`
- `interactive-image`: изменены размеры точек по умолчанию для desktop
- `interactive-image`: добавлена возможность задавать размеры точек через className/style
- `interactive-image`: добавлены тесты, правки stories

Closes #127 

