### PR TITLE
#12020 Поправить работу hover-slider в сафари

### DIFF
--- a/src/common/components/hover-slider/__test__/hover-slider.test.tsx
+++ b/src/common/components/hover-slider/__test__/hover-slider.test.tsx
@@ -168,7 +168,41 @@ describe('HoverSlider', () => {
 
     expect(rootRef.current === getByTestId('hover-slider')).toBe(true);
   });
+  it('should ignore handler on mousemove of root element if is scrolling', () => {
+    jest.useFakeTimers();
+    const { container, getByTestId } = render(
+      <HoverSlider>
+        <HoverSliderItem>
+          <img src='/public/foo.jpg' alt='' />
+        </HoverSliderItem>
+        <HoverSliderItem>
+          <img src='/public/bar.jpg' alt='' />
+        </HoverSliderItem>
+        <HoverSliderItem>
+          <img src='/public/baz.jpg' alt='' />
+        </HoverSliderItem>
+      </HoverSlider>,
+    );
 
+    const root = getByTestId('hover-slider');
+    const list = container.querySelector('.list')!;
+
+    // mock client rect
+    const rect = new DOMRectReadOnlyMock(0, 0, 100, 100);
+    jest.spyOn(root, 'getBoundingClientRect').mockReturnValue(rect);
+    jest.spyOn(list, 'getBoundingClientRect').mockReturnValue(rect);
+
+    // mock scrollWidth
+    jest.spyOn(list, 'scrollWidth', 'get').mockReturnValue(300);
+
+    expect(root.getBoundingClientRect().width).toEqual(100);
+    expect(root.getBoundingClientRect().height).toEqual(100);
+    expect(list.scrollWidth).toBe(300);
+    expect(list.scrollLeft).toBe(0);
+    fireEvent.scroll(list, { target: { scrollLeft: 100 } });
+    fireEvent.mouseMove(root, { clientX: 20 });
+    expect(list.scrollLeft).toBe(100);
+  });
   it('should change scrollLeft on mousemove/onmouseleave of root element', () => {
     const { container, getByTestId } = render(
       <HoverSlider>
@@ -214,6 +248,7 @@ describe('HoverSlider', () => {
   });
 
   it('should sync nav on scroll of list element', () => {
+    jest.useFakeTimers();
     const { container, getByTestId } = render(
       <HoverSlider>
         <HoverSliderItem>
@@ -254,5 +289,6 @@ describe('HoverSlider', () => {
     expect(navItems[0].classList.contains('nav-item-active')).toBe(false);
     expect(navItems[1].classList.contains('nav-item-active')).toBe(true);
     expect(navItems[2].classList.contains('nav-item-active')).toBe(false);
+    jest.runAllTimers();
   });
 });

--- a/src/common/components/hover-slider/__test__/utils.test.tsx
+++ b/src/common/components/hover-slider/__test__/utils.test.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useContext, useEffect } from 'react';
-import { HoverSliderContext, useSlideCount } from '../utils';
+import { debounce, HoverSliderContext, useSlideCount } from '../utils';
 import { render } from '@testing-library/react';
 
 function TestSlider({ children }: { children?: ReactNode }) {
@@ -71,5 +71,20 @@ describe('useSlideCount', () => {
     const { unmount } = render(<TestSlide slideId='1' />);
 
     expect(unmount).not.toThrow();
+  });
+});
+
+describe('debounce', () => {
+  jest.useFakeTimers();
+  it('should call fn after 100ms and only once', () => {
+    const fakeCall = jest.fn();
+    expect(fakeCall).toHaveBeenCalledTimes(0);
+    const fn = debounce(fakeCall, 100);
+    fn();
+    fn();
+    fn();
+    fn();
+    jest.runAllTimers();
+    expect(fakeCall).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/common/components/hover-slider/hover-slider.tsx
+++ b/src/common/components/hover-slider/hover-slider.tsx
@@ -71,7 +71,6 @@ export function HoverSlider({
 
     /** @inheritdoc */
     const onMouseLeave = () => {
-      setIsScrolling(false);
       list.scrollLeft = 0;
       setActiveIndex(0);
     };

--- a/src/common/components/hover-slider/hover-slider.tsx
+++ b/src/common/components/hover-slider/hover-slider.tsx
@@ -1,6 +1,14 @@
-import { useContext, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { HoverSliderProps, HoverSliderItemProps } from './types';
-import { HoverSliderContext, useSlideCount } from './utils';
+import { debounce, HoverSliderContext, useSlideCount } from './utils';
 import { HoverSliderNav } from './hover-slider-nav';
 import { useIsomorphicLayoutEffect } from '@sima-land/ui-nucleons/hooks';
 import { on } from '@sima-land/ui-nucleons/helpers';
@@ -23,10 +31,18 @@ export function HoverSlider({
   'data-testid': testId = 'hover-slider',
   ...restProps
 }: HoverSliderProps) {
+  const [isScrolling, setIsScrolling] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const [activeIndex, setActiveIndex] = useState<number>(0);
   const { count, contextValue } = useSlideCount();
+
+  const scrollingEnd = useCallback(
+    debounce(() => {
+      setIsScrolling(false);
+    }, 100),
+    [],
+  );
 
   useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(
     rootRefProp,
@@ -44,6 +60,7 @@ export function HoverSlider({
 
     /** @inheritdoc */
     const onMouseMove = (event: MouseEvent) => {
+      if (isScrolling) return;
       const rootRect = root.getBoundingClientRect();
       const rootClientX = event.clientX - rootRect.left;
       const imageIndex = Math.floor(rootClientX / (rootRect.width / count));
@@ -54,6 +71,7 @@ export function HoverSlider({
 
     /** @inheritdoc */
     const onMouseLeave = () => {
+      setIsScrolling(false);
       list.scrollLeft = 0;
       setActiveIndex(0);
     };
@@ -67,7 +85,7 @@ export function HoverSlider({
     return () => {
       off.forEach(fn => fn());
     };
-  }, [count]);
+  }, [count, isScrolling]);
 
   useEffect(() => {
     const list = listRef.current;
@@ -78,7 +96,9 @@ export function HoverSlider({
 
     /** @inheritdoc */
     const onScroll = () => {
+      setIsScrolling(true);
       setActiveIndex(Math.round(list.scrollLeft / list.getBoundingClientRect().width));
+      scrollingEnd();
     };
 
     const off = [
@@ -89,7 +109,7 @@ export function HoverSlider({
     return () => {
       off.forEach(fn => fn());
     };
-  }, [count]);
+  }, [count, isScrolling]);
 
   return (
     <HoverSliderContext.Provider value={contextValue}>

--- a/src/common/components/hover-slider/utils.ts
+++ b/src/common/components/hover-slider/utils.ts
@@ -24,3 +24,16 @@ export function useSlideCount() {
 
   return { count: slideIds.length, contextValue };
 }
+
+/**
+ * @param fn Функция вызова.
+ * @param ms Задержка в миллисекундах.
+ * @return Функция вызова.
+ */
+export const debounce = <T>(fn: (...args: T[]) => void, ms: number) => {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  return function (this: any, ...args: any[]) {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn.apply(this, args), ms);
+  };
+};


### PR DESCRIPTION
- Была найдена проблема работы скролла и события `mousemove` между собой, после скроллинга событие срабатывало вновь на всех версиях safari, так что было решено добавить debounce при скроллинге, чтобы в течении небольшой задержки после скроллинга в 100мс, не срабатывало событие `mousemove`
- Было решено добавить свою реализацию debounce чтобы не тащить её из lodash

Пример нынейшней работы на safari:


https://github.com/user-attachments/assets/8e0205a6-948a-4b04-ace8-c795622dd62b

