### PR TITLE
#309 Modifier: Модификаторы несуществующих вариантов отображаются некорректно (мобверсия)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "jest": "^29.6.4",
         "jest-environment-jsdom": "^29.6.4",
         "lint-staged": "^15.2.10",
-        "prettier": "^3.3.3",
+        "prettier": "^3.5.3",
         "react": "^18.2.0",
         "sass": "^1.77.8",
         "stylelint": "^15.11.0",
@@ -11116,10 +11116,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jest": "^29.6.4",
     "jest-environment-jsdom": "^29.6.4",
     "lint-staged": "^15.2.10",
-    "prettier": "^3.3.3",
+    "prettier": "^3.5.3",
     "react": "^18.2.0",
     "sass": "^1.77.8",
     "stylelint": "^15.11.0",

--- a/src/common/components/modifier/default-border.svg
+++ b/src/common/components/modifier/default-border.svg
@@ -1,3 +1,14 @@
-<svg width="33" height="33" viewBox="0 0 33 33" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="0.5" y="0.5" width="32" height="32" rx="3.5" stroke="rgba(194, 194, 194, 1)" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="5 5" stroke-dashoffset="3.8"/>
+<svg width="62" height="62" viewBox="0 0 62.5 62.5" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect
+    x="0.5"
+    y="0.5"
+    width="61.5"
+    height="61.5"
+    rx="3.5"
+    stroke="rgba(194, 194, 194, 1)"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-dasharray="5 5"
+    stroke-dashoffset="5"
+  />
 </svg>

--- a/src/common/components/modifier/hover-border.svg
+++ b/src/common/components/modifier/hover-border.svg
@@ -1,3 +1,14 @@
-<svg width="33" height="33" viewBox="0 0 33 33" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="0.5" y="0.5" width="32" height="32" rx="3.5" stroke="rgba(158, 158, 158, 1)" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="5 5" stroke-dashoffset="3.8"/>
+<svg width="62" height="62" viewBox="0 0 62.5 62.5" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect
+    x="0.5"
+    y="0.5"
+    width="61.5"
+    height="61.5"
+    rx="3.5"
+    stroke="rgba(158, 158, 158, 1)"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-dasharray="5 5"
+    stroke-dashoffset="5"
+  />
 </svg>


### PR DESCRIPTION
- Доработал SVG изображения

**100% масштаб**
<img width="1399" alt="Снимок экрана 2025-05-21 в 13 54 56" src="https://github.com/user-attachments/assets/eecb3c0d-61a7-4c6f-baf2-6a9417e9e2e3" />

**80% масштаб**
<img width="1089" alt="Снимок экрана 2025-05-21 в 13 55 07" src="https://github.com/user-attachments/assets/bdc790b9-72a6-43a0-8be9-0f450fe476f3" />
