### PR TITLE
FIX #13091 Moleculas: Компонент PromotionCard. Доработать таймер акции

### DIFF
--- a/src/desktop/components/promotion-card/__test__/__snapshots__/banner-title.test.tsx.snap
+++ b/src/desktop/components/promotion-card/__test__/__snapshots__/banner-title.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`BannerTitle should renders correctly 3`] = `
     data-testid="promotion-card:banner-timer"
   >
     <svg
+      class="part"
       fill="#3a3a3b"
       viewBox="0 0 40 40"
     >
@@ -22,34 +23,36 @@ exports[`BannerTitle should renders correctly 3`] = `
         class="value"
         text-anchor="middle"
         x="20"
-        y="70%"
+        y="65%"
       >
         09
       </text>
       <text
         class="label"
-        dy="100%"
+        dy="95%"
         text-anchor="middle"
         x="20"
-        y="10%"
+        y="0"
       >
         дней
       </text>
     </svg>
     <svg
+      class="divider-wrap"
       fill="#3a3a3b"
-      viewBox="0 0 26 40"
+      viewBox="0 0 12 40"
     >
       <text
         class="divider"
         text-anchor="middle"
-        x="13"
-        y="70%"
+        x="6"
+        y="78%"
       >
         :
       </text>
     </svg>
     <svg
+      class="part"
       fill="#3a3a3b"
       viewBox="0 0 40 40"
     >
@@ -57,34 +60,36 @@ exports[`BannerTitle should renders correctly 3`] = `
         class="value"
         text-anchor="middle"
         x="20"
-        y="70%"
+        y="65%"
       >
         00
       </text>
       <text
         class="label"
-        dy="100%"
+        dy="95%"
         text-anchor="middle"
         x="20"
-        y="10%"
+        y="0"
       >
         часов
       </text>
     </svg>
     <svg
+      class="divider-wrap"
       fill="#3a3a3b"
-      viewBox="0 0 26 40"
+      viewBox="0 0 12 40"
     >
       <text
         class="divider"
         text-anchor="middle"
-        x="13"
-        y="70%"
+        x="6"
+        y="78%"
       >
         :
       </text>
     </svg>
     <svg
+      class="part"
       fill="#3a3a3b"
       viewBox="0 0 40 40"
     >
@@ -92,16 +97,16 @@ exports[`BannerTitle should renders correctly 3`] = `
         class="value"
         text-anchor="middle"
         x="20"
-        y="70%"
+        y="65%"
       >
         00
       </text>
       <text
         class="label"
-        dy="100%"
+        dy="95%"
         text-anchor="middle"
         x="20"
-        y="10%"
+        y="0"
       >
         минут
       </text>

--- a/src/desktop/components/promotion-card/__test__/__snapshots__/promotion-card.test.tsx.snap
+++ b/src/desktop/components/promotion-card/__test__/__snapshots__/promotion-card.test.tsx.snap
@@ -107,6 +107,7 @@ exports[`PromotionCard should render with "type=special" 1`] = `
       data-testid="promotion-card:banner-timer"
     >
       <svg
+        class="part"
         fill="#3a3a3b"
         viewBox="0 0 40 40"
       >
@@ -114,34 +115,36 @@ exports[`PromotionCard should render with "type=special" 1`] = `
           class="value"
           text-anchor="middle"
           x="20"
-          y="70%"
+          y="65%"
         >
           00
         </text>
         <text
           class="label"
-          dy="100%"
+          dy="95%"
           text-anchor="middle"
           x="20"
-          y="10%"
+          y="0"
         >
           дней
         </text>
       </svg>
       <svg
+        class="divider-wrap"
         fill="#3a3a3b"
-        viewBox="0 0 26 40"
+        viewBox="0 0 12 40"
       >
         <text
           class="divider"
           text-anchor="middle"
-          x="13"
-          y="70%"
+          x="6"
+          y="78%"
         >
           :
         </text>
       </svg>
       <svg
+        class="part"
         fill="#3a3a3b"
         viewBox="0 0 40 40"
       >
@@ -149,34 +152,36 @@ exports[`PromotionCard should render with "type=special" 1`] = `
           class="value"
           text-anchor="middle"
           x="20"
-          y="70%"
+          y="65%"
         >
           00
         </text>
         <text
           class="label"
-          dy="100%"
+          dy="95%"
           text-anchor="middle"
           x="20"
-          y="10%"
+          y="0"
         >
           часов
         </text>
       </svg>
       <svg
+        class="divider-wrap"
         fill="#3a3a3b"
-        viewBox="0 0 26 40"
+        viewBox="0 0 12 40"
       >
         <text
           class="divider"
           text-anchor="middle"
-          x="13"
-          y="70%"
+          x="6"
+          y="78%"
         >
           :
         </text>
       </svg>
       <svg
+        class="part"
         fill="#3a3a3b"
         viewBox="0 0 40 40"
       >
@@ -184,16 +189,16 @@ exports[`PromotionCard should render with "type=special" 1`] = `
           class="value"
           text-anchor="middle"
           x="20"
-          y="70%"
+          y="65%"
         >
           00
         </text>
         <text
           class="label"
-          dy="100%"
+          dy="95%"
           text-anchor="middle"
           x="20"
-          y="10%"
+          y="0"
         >
           минут
         </text>

--- a/src/desktop/components/promotion-card/banner-title.m.scss
+++ b/src/desktop/components/promotion-card/banner-title.m.scss
@@ -14,13 +14,19 @@
   display: flex;
   font-weight: bold;
   width: 100%;
-  .value {
-    font-size: 74%;
+  .part {
+    width: 30%;
+    .value {
+      font-size: 62%;
+    }
+    .label {
+      font-size: 25%;
+    }
   }
-  .label {
-    font-size: 30%;
-  }
-  .divider {
-    font-size: 74%;
+  .divider-wrap {
+    width: 5%;
+    .divider {
+      font-size: 100%;
+    }
   }
 }

--- a/src/desktop/components/promotion-card/banner-title.tsx
+++ b/src/desktop/components/promotion-card/banner-title.tsx
@@ -70,11 +70,11 @@ export const CustomTimer = ({ dueDate }: { dueDate: Date }) => (
  * @return Элемент.
  */
 const TimerPart = ({ label, value }: { label: string; value: number }) => (
-  <svg viewBox='0 0 40 40' fill={COLORS.get('basic-gray76')}>
-    <text x='20' y='70%' className={styles.value} textAnchor='middle'>
+  <svg viewBox='0 0 40 40' fill={COLORS.get('basic-gray76')} className={styles.part}>
+    <text x='20' y='65%' className={styles.value} textAnchor='middle'>
       {`${value}`.padStart(2, '0')}
     </text>
-    <text x='20' y='10%' dy='100%' className={styles.label} textAnchor='middle'>
+    <text x='20' y='0' dy='95%' className={styles.label} textAnchor='middle'>
       {label}
     </text>
   </svg>
@@ -85,8 +85,8 @@ const TimerPart = ({ label, value }: { label: string; value: number }) => (
  * @return Элемент.
  */
 const TimerDivider = () => (
-  <svg viewBox='0 0 26 40' fill={COLORS.get('basic-gray76')}>
-    <text x='13' y='70%' className={styles.divider} textAnchor='middle'>
+  <svg viewBox='0 0 12 40' fill={COLORS.get('basic-gray76')} className={styles['divider-wrap']}>
+    <text x='6' y='78%' className={styles.divider} textAnchor='middle'>
       :
     </text>
   </svg>

--- a/src/desktop/components/promotion-card/promotion-card.m.scss
+++ b/src/desktop/components/promotion-card/promotion-card.m.scss
@@ -35,6 +35,13 @@
 
   // для исправления бага Safari border-radius
   -webkit-mask-image: -webkit-radial-gradient(#fff, #000);
+  .stub {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
 }
 
 .image {
@@ -45,14 +52,6 @@
   height: 100%;
   object-fit: cover;
   transition: transform 0.2s ease-out;
-}
-
-.stub {
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
 }
 
 .banner-content {


### PR DESCRIPTION

- PromotionCard: переделал параметры svg таймера, для учета разной ширины шрифтов

<details><summary>Было</summary>
     
<img src='https://github.com/user-attachments/assets/38885065-d6ed-49c9-97f8-692260733f72' width=500 />

</details>

<details><summary>Стало</summary>
     
[diff-width.webm](https://github.com/user-attachments/assets/e068a4d7-0081-4e36-95ff-2f1accc07190)

</details>

- PromotionCard: перенёс класс для стилей заглушки фото, для большей специфичности
